### PR TITLE
Add note about v8 web SDK usage

### DIFF
--- a/steps/index.lab.md
+++ b/steps/index.lab.md
@@ -12,6 +12,12 @@ tags: web
 
 ## Before you begin
 
+> aside negative
+This codelab uses v8 of the Firebase JavaScript SDKs. It is recommended that you use
+v9 for your applications. This codelab will soon be updated to v9. The concepts
+described in this codelab are still valid. See Firebase documentation to
+[learn more about SDK versions 8 and 9](https://firebase.google.com/docs/web/learn-more?authuser=0#modular-version).
+
 Serverless backend tools like Cloud Firestore and Cloud Functions are very easy to use, but can be hard to test.  The Firebase Local Emulator Suite allows you to run local versions of these services on your development machine so you can develop your app quickly and safely.
 
 ### **Prerequisites**


### PR DESCRIPTION
This codelab uses v8 of the Firebase web SDK. v9 is the recommended version so adding a note here till the codelab is migrated to v9.