### PR TITLE
go get --> go install

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ Install the `claat` tool from this repo:
 https://github.com/googlecodelabs/tools
 
 ```
-go get github.com/googlecodelabs/tools/claat
+go install github.com/googlecodelabs/tools/claat@latest
 ```
 
 ### node


### PR DESCRIPTION
`go get` has been deprecated in favor of `go install`: https://go.dev/doc/go-get-install-deprecation